### PR TITLE
Gamepad array updates when controllers has just been  connected/disconnected

### DIFF
--- a/plugins/gamepad-plugin-1.0.0.js
+++ b/plugins/gamepad-plugin-1.0.0.js
@@ -87,10 +87,31 @@ Kiwi.Plugins.Gamepad.Manager = function( game ) {
 	var self = this;
 	window.addEventListener("gamepadconnected", function( event ) {
 		// console.log( "connected" );
+
+		//	If a new controller has just been connected:
+		//	update the gamepad array
+		var newLength = navigator.getGamepads().length;
+		if(gamepadLength < newLength)
+		{
+			while(newLength > gamepadLength)
+			{
+				self.gamepads.push(new Kiwi.Plugins.Gamepad.Controller( this, 0.25, 0.25 ));
+				gamepadLength++;
+			}
+		}
+		//console.log(self.gamepads);
+
 		self.gamepadConnected.dispatch( event.gamepad );
 	});
 	window.addEventListener("gamepaddisconnected", function( event ) {
 		// console.log( "disconnected" );
+
+		//	Remove deconnected controller from the gamepad array
+		var gamepadIndex = self.gamepads.indexOf(event.gamepad);
+		self.gamepads.splice(gamepadIndex);
+		gamepadLength--;
+		//console.log("Controller : " + event.gamepad + " disconnected.");
+
 		self.gamepadDisconnected.dispatch( event.gamepad);
 	});
 


### PR DESCRIPTION
I've just started to used your Gamepad plugin for Kiwi.js, and I encountered a problem.
The game pads in your plugin are checked only once when the plugin is loaded, but the 
fact is that a button has to be pressed in order for the browser to detect the controller.
I've just made some code to update the gamepad array when a controller has just been connected / diconnected.
